### PR TITLE
Implement kotlin/js target

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ kotlin.code.style=official
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 android.enableJetifier=true
+org.jetbrains.compose.experimental.jscanvas.enabled=true

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -29,6 +29,10 @@ kotlin {
         browser()
     }
 
+    js(IR) {
+        browser()
+    }
+
     sourceSets {
         val commonMain by getting {
             dependencies {
@@ -87,6 +91,8 @@ kotlin {
                 api(compose.desktop.common)
             }
         }
+
+        val jsMain by getting
     }
 }
 

--- a/shared/src/commonMain/kotlin/core/util/Platform.kt
+++ b/shared/src/commonMain/kotlin/core/util/Platform.kt
@@ -3,6 +3,7 @@ package core.util
 enum class Platform {
     ANDROID,
     WASM,
+    JS,
     DESKTOP
 }
 

--- a/shared/src/commonMain/kotlin/feature/app/App.kt
+++ b/shared/src/commonMain/kotlin/feature/app/App.kt
@@ -13,8 +13,6 @@ import androidx.compose.material.icons.twotone.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
-import core.util.Platform
-import core.util.getPlatform
 import core.util.navigation.Screen
 import core.viewmodel.ProvideViewModel
 import feature.details.CharacterDetailsScreen
@@ -30,29 +28,27 @@ fun App(
     val hasBackStack = viewModel.hasBackStack.collectAsState(false).value
     val screen = viewModel.currentScreen.collectAsState().value
 
-    if (getPlatform() != Platform.WASM) {
-        if (hasBackStack) {
-            TopAppBar(
-                title = {
-                    Text(screen.name)
-                },
-                navigationIcon = {
-                    IconButton(onClick = viewModel::onBack) {
-                        Icon(
-                            Icons.TwoTone.ArrowBack,
-                            contentDescription = null
-                        )
-                    }
+    if (hasBackStack) {
+        TopAppBar(
+            title = {
+                Text(screen.name)
+            },
+            navigationIcon = {
+                IconButton(onClick = viewModel::onBack) {
+                    Icon(
+                        Icons.TwoTone.ArrowBack,
+                        contentDescription = null
+                    )
                 }
-            )
-        } else {
-            TopAppBar(
-                title = {
-                    Text(screen.name)
-                },
-                navigationIcon = null
-            )
-        }
+            }
+        )
+    } else {
+        TopAppBar(
+            title = {
+                Text(screen.name)
+            },
+            navigationIcon = null
+        )
     }
 
     val charactersState = rememberLazyStaggeredGridState()
@@ -67,7 +63,6 @@ fun App(
         is Screen.CharacterDetails -> {
             CharacterDetailsScreen(
                 character = screen.character,
-                onNavigate = viewModel::onNavigate,
                 modifier = Modifier.fillMaxSize()
             )
         }

--- a/shared/src/commonMain/kotlin/feature/details/CharacterDetailsScreen.kt
+++ b/shared/src/commonMain/kotlin/feature/details/CharacterDetailsScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.Button
 import androidx.compose.material.Card
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Text
@@ -18,8 +17,6 @@ import core.designSystem.BodyStyle
 import core.designSystem.CharacterDetails
 import core.designSystem.LinkColor
 import core.designSystem.SubTitleStyle
-import core.util.Platform
-import core.util.getPlatform
 import core.util.navigation.Navigate
 import domain.model.Character
 
@@ -93,14 +90,6 @@ fun CharacterDetailsScreen(
     }
 
     Spacer(Modifier.height(16.dp))
-
-    if (getPlatform() == Platform.WASM) {
-        Button(
-             onClick = { onNavigate(Navigate.Back) }
-        ) {
-            Text("voltar")
-        }
-    }
 }
 
 

--- a/shared/src/jsMain/kotlin/core/extension/ByteArray.kt
+++ b/shared/src/jsMain/kotlin/core/extension/ByteArray.kt
@@ -1,0 +1,7 @@
+package core.extension
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import org.jetbrains.skia.Image
+
+actual fun ByteArray.toImageBitmap(): ImageBitmap = Image.makeFromEncoded(this).toComposeImageBitmap()

--- a/shared/src/jsMain/kotlin/core/util/Platform.kt
+++ b/shared/src/jsMain/kotlin/core/util/Platform.kt
@@ -1,0 +1,3 @@
+package core.util
+
+actual fun getPlatform() = Platform.JS

--- a/shared/src/jsMain/kotlin/core/viewmodel/BaseViewModel.kt
+++ b/shared/src/jsMain/kotlin/core/viewmodel/BaseViewModel.kt
@@ -1,0 +1,8 @@
+package core.viewmodel
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.MainScope
+
+actual open class BaseViewModel actual constructor() {
+    actual val scope: CoroutineScope = MainScope()
+}

--- a/shared/src/jsMain/kotlin/core/viewmodel/ProvideViewModel.kt
+++ b/shared/src/jsMain/kotlin/core/viewmodel/ProvideViewModel.kt
@@ -1,0 +1,22 @@
+package core.viewmodel
+
+import androidx.compose.runtime.Composable
+import feature.app.AppViewModel
+import feature.home.HomeViewModel
+
+actual object ProvideViewModel {
+
+    private val appViewModel by lazy { AppViewModel() }
+
+    private val homeViewModel by lazy { HomeViewModel() }
+
+    @Composable
+    actual fun provideAppViewModel(): AppViewModel {
+        return appViewModel
+    }
+
+    @Composable
+    actual fun provideHomeViewModel(): HomeViewModel {
+        return homeViewModel
+    }
+}

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -13,8 +13,14 @@ kotlin {
 
     wasm {
 
-        // Used in load.mjs
-        moduleName = "webAppModule"
+        moduleName = "web"
+
+        binaries.executable()
+
+        browser()
+    }
+
+    js(IR) {
 
         binaries.executable()
 
@@ -22,11 +28,16 @@ kotlin {
     }
 
     sourceSets {
-        val wasmMain by getting  {
+
+        val commonMain by getting {
             dependencies {
-                implementation(project(":shared"))
+                api(project(":shared"))
             }
         }
+
+        val wasmMain by getting
+
+        val jsMain by getting
     }
 }
 

--- a/web/src/jsMain/kotlin/Main.kt
+++ b/web/src/jsMain/kotlin/Main.kt
@@ -1,0 +1,18 @@
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.window.CanvasBasedWindow
+import feature.app.App
+import org.jetbrains.skiko.wasm.onWasmReady
+
+@OptIn(ExperimentalComposeUiApi::class)
+fun main() {
+    onWasmReady {
+        CanvasBasedWindow {
+            MaterialTheme {
+                App(Modifier.fillMaxSize())
+            }
+        }
+    }
+}

--- a/web/src/jsMain/resources/index.html
+++ b/web/src/jsMain/resources/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Rick And Morty</title>
+    <script type="application/javascript" src="skiko.js"></script>
+    <style>
+        html, body, canvas {
+            margin: 0;
+            padding: 0;
+            display:block;
+            margin: 0 auto;
+            background: #CCCCCC;
+         }
+    </style>
+</head>
+<body>
+    <canvas id="ComposeTarget"></canvas>
+    <script src="web.js"> </script>
+</body>
+</html>

--- a/web/src/wasmMain/resources/load.mjs
+++ b/web/src/wasmMain/resources/load.mjs
@@ -1,4 +1,4 @@
-import { instantiate } from './webAppModule.uninstantiated.mjs';
+import { instantiate } from './web.uninstantiated.mjs';
 
 await wasmSetup;
 


### PR DESCRIPTION
I added the Kotlin/JS target and used [skiko](https://github.com/JetBrains/skiko/blob/master/samples/SkiaJsSample/src/jsMain/kotlin/org/jetbrains/skiko/sample/js/App.kt) to render the UI on the canvas using Wasm, run `gradlew web:jsBrowserRun` to test

**Note:** In this target, unlike the Kotlin/Wasm target, the classes will be transpiled to JS and not compiled to Wasm, but the UI in Compose will still be rendered using Wasm, through [skiko](https://github.com/JetBrains/skiko)

**Skiko:** Is a multiplatform graphical library based on [skia](https://skia.org/), compatible with compose multiplatform